### PR TITLE
Update tl_content.php

### DIFF
--- a/dca/tl_content.php
+++ b/dca/tl_content.php
@@ -30,7 +30,7 @@
 
 $GLOBALS['TL_DCA']['tl_content']['palettes']['teaser'] = str_replace('{include_legend},article', '{include_legend},article,teaser_page_link,teaser_fragment_identifier', $GLOBALS['TL_DCA']['tl_content']['palettes']['teaser']);
 
-$GLOBALS['TL_DCA']['tl_content']['palettes']['page_teaser'] = '{type_legend},type,headline;{page_teaser_text_legend},text;{page_teaser_page_legend},page_teaser_page,page_teaser_show_more;{image_legend},addImage;{expert_legend:hide},cssID,space';
+$GLOBALS['TL_DCA']['tl_content']['palettes']['page_teaser'] = '{type_legend},type,headline;{page_teaser_text_legend},text;{page_teaser_page_legend},page_teaser_page,page_teaser_show_more;{image_legend},addImage;{expert_legend:hide},cssID,space;{invisible_legend:hide},invisible,start,stop';
 
 #$GLOBALS['TL_DCA']['tl_content']['config']['oncopy_callback'][] = array('page_teaser', 'copyTeaser');
 $GLOBALS['TL_DCA']['tl_page']['config']['oncopy_callback'][] = array('page_teaser', 'copyPage');


### PR DESCRIPTION
Hallo Mario, 
wäre es möglich in dem nächsten Realease, die "Sichtbarkeit" Legende mit den Feldern "invisible, start und stop" in die Palette für den PageTeaser mitaufzunehmen. Im core tl_content sind diese Felder und Funktionalität bereits, so dass es weiter nichts braucht, als sie in der Palette hinzuzufügen, damit diese Funktionalität auch für den PageTeaser genutzt werden kann. Wir brauchen diese Felder für unseren Kunden. Das wäre wirklich super. Herzliche Grüsse und vielen Dank für eine kurze Rückmeldung.